### PR TITLE
Arguments, help formatter, and Demo notebook.

### DIFF
--- a/Demo.ipynb
+++ b/Demo.ipynb
@@ -1,12 +1,42 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Demo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. `black`\n",
+    "\n",
+    "**An IPython cell magic to format code cells using [Black](https://github.com/psf/black).**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First of all, load (\"import\") the respective extension (\"module\"):"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "%load_ext mahou"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, imagine that you have a code cell that you would like to format, like this one:"
    ]
   },
   {
@@ -20,6 +50,13 @@
     "x = {  F'{first_key}':1,'b':2,\n",
     "\n",
     "'c':3}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To format the code in the cell, insert `%%black` at the top of the cell and run it:"
    ]
   },
   {
@@ -38,6 +75,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The cell executed with this cell magic will be \"rewritten\" with the code after formatting using [Black](https://github.com/psf/black):"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -49,12 +93,26 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For more information on how to use `black`, as well as to check the available options (a cell magic with arguments works like an [argparse](https://docs.python.org/3/library/argparse.html)-based CLI), run the following cell:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "%%black?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---"
    ]
   }
  ],

--- a/Demo.ipynb
+++ b/Demo.ipynb
@@ -41,6 +41,30 @@
    "source": [
     "x = {\"a\": 1, \"b\": 2, \"c\": 3}"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "first_key = \"a\"\n",
+    "x = {f\"{first_key}\": 1, \"b\": 2, \"c\": 3}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/Demo.ipynb
+++ b/Demo.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,11 +11,22 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%black?"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "x = {  'a':1,'b':2,\n",
+    "first_key  = \"a\"\n",
+    "\n",
+    "x = {  F'{first_key}':1,'b':2,\n",
     "\n",
     "'c':3}"
    ]
@@ -26,11 +37,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%black\n",
+    "first_key = \"a\"\n",
     "\n",
-    "x = {  'a':1,'b':2,\n",
-    "\n",
-    "'c':3}"
+    "x = {f\"{first_key}\": 1, \"b\": 2, \"c\": 3}"
    ]
   },
   {
@@ -39,7 +48,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x = {\"a\": 1, \"b\": 2, \"c\": 3}"
+    "first_key = \"a\"\n",
+    "\n",
+    "x = {f\"{first_key}\": 1, \"b\": 2, \"c\": 3}"
    ]
   },
   {

--- a/Demo.ipynb
+++ b/Demo.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,11 +11,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%black?"
+    "first_key  = \"a\"\n",
+    "\n",
+    "x = {  F'{first_key}':1,'b':2,\n",
+    "\n",
+    "'c':3}"
    ]
   },
   {
@@ -24,6 +28,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%black\n",
+    "\n",
     "first_key  = \"a\"\n",
     "\n",
     "x = {  F'{first_key}':1,'b':2,\n",
@@ -48,34 +54,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "first_key = \"a\"\n",
-    "\n",
-    "x = {f\"{first_key}\": 1, \"b\": 2, \"c\": 3}"
+    "%%black?"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "first_key = \"a\"\n",
-    "x = {f\"{first_key}\": 1, \"b\": 2, \"c\": 3}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/Demo.ipynb
+++ b/Demo.ipynb
@@ -96,7 +96,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more information on how to use `black`, as well as to check the available options (a cell magic with arguments works like an [argparse](https://docs.python.org/3/library/argparse.html)-based CLI), run the following cell:"
+    "For more information on how to use `black`, as well as to check the available options (a cell magic with arguments works like an [`argparse`](https://docs.python.org/3/library/argparse.html)-based CLI), run the following cell:"
    ]
   },
   {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mahou
 
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
 A package full of tricks... sorry, full of IPython magic commands.
 
 ## Commands
@@ -13,6 +15,7 @@ A package full of tricks... sorry, full of IPython magic commands.
 ## Documentation
 
 - Black:
+  - [CLI options](https://github.com/psf/black/blob/master/README.md#command-line-options).
   - [`format_str()`](https://github.com/psf/black/blob/master/src/black/__init__.py#L943) function.
   - [`Mode`](https://github.com/psf/black/blob/master/src/black/__init__.py#L240) class.
   - [`TargetVersion`](https://github.com/psf/black/blob/master/src/black/__init__.py#L169) enum class.

--- a/mahou/formatter.py
+++ b/mahou/formatter.py
@@ -3,10 +3,16 @@ from IPython.core import magic_arguments
 from IPython.core.debugger import set_trace
 from IPython.core.magic import Magics, cell_magic, magics_class
 
+from .utils import MagicArgumentDefaultsHelpFormatter
+
 
 @magics_class
 class Formatter(Magics):
-    @magic_arguments.magic_arguments()
+    @magic_arguments.magic_arguments(name=r"%black")
+    @magic_arguments.kwds(
+        description="IPython cell magic to format code cells using Black.",
+        formatter_class=MagicArgumentDefaultsHelpFormatter,
+    )
     @magic_arguments.argument(
         "-l",
         "--line-length",
@@ -14,6 +20,7 @@ class Formatter(Magics):
         default=DEFAULT_LINE_LENGTH,
         help="Number of characters allowed per line.",
         dest="line_length",
+        metavar="INT",
     )
     @magic_arguments.argument(
         "-S",
@@ -22,9 +29,18 @@ class Formatter(Magics):
         help="Don't normalize string quote marks and prefixes.",
         dest="string_normalization",
     )
+    @magic_arguments.argument(
+        "-N",
+        "--skip-final-newline-character-removal",
+        action="store_true",
+        help="Don't remove the newline character (`\\n`) at the end of the cell after formatting.",
+        dest="final_newline",
+    )
     @cell_magic
     def black(self, line, cell):
         args = magic_arguments.parse_argstring(self.black, line)
+
+        set_trace()
 
         # More info about the `--target-version` option: https://github.com/psf/black/issues/751
         mode = FileMode(
@@ -35,7 +51,7 @@ class Formatter(Magics):
         formatted_cell = format_str(cell, mode=mode)
         formatted_cell = (
             formatted_cell[:-1]
-            if formatted_cell and formatted_cell[-1] == "\n"
+            if not args.final_newline and formatted_cell and formatted_cell[-1] == "\n"
             else formatted_cell
         )
 

--- a/mahou/formatter.py
+++ b/mahou/formatter.py
@@ -1,13 +1,36 @@
-from black import FileMode, format_str
+from black import DEFAULT_LINE_LENGTH, FileMode, format_str
 from IPython.core import magic_arguments
+from IPython.core.debugger import set_trace
 from IPython.core.magic import Magics, cell_magic, magics_class
 
 
 @magics_class
 class Formatter(Magics):
+    @magic_arguments.magic_arguments()
+    @magic_arguments.argument(
+        "-l",
+        "--line-length",
+        type=int,
+        default=DEFAULT_LINE_LENGTH,
+        help="Number of characters allowed per line.",
+        dest="line_length",
+    )
+    @magic_arguments.argument(
+        "-S",
+        "--skip-string-normalization",
+        action="store_true",
+        help="Don't normalize string quote marks and prefixes.",
+        dest="string_normalization",
+    )
     @cell_magic
     def black(self, line, cell):
-        mode = FileMode()
+        args = magic_arguments.parse_argstring(self.black, line)
+
+        # More info about the `--target-version` option: https://github.com/psf/black/issues/751
+        mode = FileMode(
+            line_length=args.line_length,
+            string_normalization=not args.string_normalization,
+        )
 
         formatted_cell = format_str(cell, mode=mode)
         formatted_cell = (

--- a/mahou/formatter.py
+++ b/mahou/formatter.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from black import DEFAULT_LINE_LENGTH, FileMode, format_str
 from IPython.core import magic_arguments
 from IPython.core.debugger import set_trace
@@ -8,10 +10,11 @@ from .utils import MagicArgumentDefaultsHelpFormatter
 
 @magics_class
 class Formatter(Magics):
-    @magic_arguments.magic_arguments(name=r"%black")
+    @magic_arguments.magic_arguments()
     @magic_arguments.kwds(
         description="IPython cell magic to format code cells using Black.",
-        formatter_class=MagicArgumentDefaultsHelpFormatter,
+        formatter_class=partial(MagicArgumentDefaultsHelpFormatter, magic_prefix="%%"),
+        epilog="For more info about Black, please check: https://github.com/psf/black",
     )
     @magic_arguments.argument(
         "-l",

--- a/mahou/formatter.py
+++ b/mahou/formatter.py
@@ -2,7 +2,8 @@ from functools import partial
 
 from black import DEFAULT_LINE_LENGTH, FileMode, format_str
 from IPython.core import magic_arguments
-from IPython.core.debugger import set_trace
+
+# from IPython.core.debugger import set_trace
 from IPython.core.magic import Magics, cell_magic, magics_class
 
 from .utils import MagicArgumentDefaultsHelpFormatter
@@ -42,8 +43,6 @@ class Formatter(Magics):
     @cell_magic
     def black(self, line, cell):
         args = magic_arguments.parse_argstring(self.black, line)
-
-        set_trace()
 
         # More info about the `--target-version` option: https://github.com/psf/black/issues/751
         mode = FileMode(

--- a/mahou/utils.py
+++ b/mahou/utils.py
@@ -1,7 +1,6 @@
 from argparse import ArgumentDefaultsHelpFormatter
 
 from IPython.core.magic_arguments import MagicHelpFormatter
-from IPython.utils.text import dedent
 
 
 class MagicArgumentDefaultsHelpFormatter(
@@ -11,7 +10,8 @@ class MagicArgumentDefaultsHelpFormatter(
     More info:
 
     - IPython: https://github.com/ipython/ipython/blob/master/IPython/core/magic_arguments.py#L65
-    - argparse: https://github.com/python/cpython/blob/3.8/Lib/argparse.py#L679
+    - argparse (`HelpFormatter`): https://github.com/python/cpython/blob/3.8/Lib/argparse.py#L154
+    - argparse (`ArgumentDefaultsHelpFormatter`): https://github.com/python/cpython/blob/3.8/Lib/argparse.py#L679
 
     Check if inheritance is as expected:
 
@@ -20,7 +20,24 @@ class MagicArgumentDefaultsHelpFormatter(
     inspect.getmembers(MagicArgumentDefaultsHelpFormatter, predicate=inspect.isfunction)
     """
 
-    def add_usage(self, usage, actions, groups, prefix="teste"):
+    def __init__(
+        self,
+        prog,
+        indent_increment=2,
+        max_help_position=24,
+        width=None,
+        magic_prefix="%",
+    ):
+        super().__init__(
+            prog=prog,
+            indent_increment=indent_increment,
+            max_help_position=max_help_position,
+            width=width,
+        )
+
+        self.magic_prefix = magic_prefix
+
+    def add_usage(self, usage, actions, groups, prefix="::\n\n  "):
         super(MagicArgumentDefaultsHelpFormatter, self).add_usage(
-            usage, actions, groups, prefix
+            usage, actions, groups, f"{prefix}{self.magic_prefix}"
         )

--- a/mahou/utils.py
+++ b/mahou/utils.py
@@ -1,0 +1,26 @@
+from argparse import ArgumentDefaultsHelpFormatter
+
+from IPython.core.magic_arguments import MagicHelpFormatter
+from IPython.utils.text import dedent
+
+
+class MagicArgumentDefaultsHelpFormatter(
+    MagicHelpFormatter, ArgumentDefaultsHelpFormatter
+):
+    """
+    More info:
+
+    - IPython: https://github.com/ipython/ipython/blob/master/IPython/core/magic_arguments.py#L65
+    - argparse: https://github.com/python/cpython/blob/3.8/Lib/argparse.py#L679
+
+    Check if inheritance is as expected:
+
+    import inspect
+    inspect.getmro(MagicArgumentDefaultsHelpFormatter)
+    inspect.getmembers(MagicArgumentDefaultsHelpFormatter, predicate=inspect.isfunction)
+    """
+
+    def add_usage(self, usage, actions, groups, prefix="teste"):
+        super(MagicArgumentDefaultsHelpFormatter, self).add_usage(
+            usage, actions, groups, prefix
+        )


### PR DESCRIPTION
Closes #1, closes #2, closes #3, and closes #4

## Proposed Changes

- Allow specifying the `format_str()` function arguments using magic arguments (`line_length` and `string_normalization`).
- Add a magic argument to keep or remove the newline character at the end of the cell. 
- Create a custom `MagicHelpFormatter` class (`MagicArgumentDefaultsHelpFormatter`) to be able to change the usage prefix and show the default values.
- Add Markdown cells (to the `Demo` notebook) to clarify how to use the `black` magic command.

## Types of Changes

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality not to work as expected)
